### PR TITLE
seo: add Store and BreadcrumbList structured data to homepage

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -43,6 +43,67 @@ export const Head = (props: any) => {
     ],
   };
 
+  const storeSchema = {
+    "@context": "https://schema.org",
+    "@type": "Store",
+    name: "Brushella Art Store",
+    url: "https://www.brushella.art",
+    logo: "https://www.brushella.art/brushella-icon.svg",
+    image:
+      "https://cdn.shopify.com/s/files/1/0586/9892/4240/files/web-asset-author.jpg?v=1729679585",
+    description:
+      "Online art store featuring original paintings, fine art prints and home décor by Australian artist Gabriela.",
+    priceRange: "$$",
+    currenciesAccepted: "AUD",
+    paymentAccepted: "Credit Card, Shop Pay",
+    founder: {
+      "@type": "Person",
+      name: "Gabriela Ugalde",
+      jobTitle: "Artist",
+    },
+    hasOfferCatalog: {
+      "@type": "OfferCatalog",
+      name: "Art & Home Decor",
+      itemListElement: [
+        {
+          "@type": "OfferCatalog",
+          name: "Original Paintings",
+          itemListElement: {
+            "@type": "Offer",
+            itemOffered: {
+              "@type": "Product",
+              name: "Original Acrylic Paintings",
+            },
+          },
+        },
+        {
+          "@type": "OfferCatalog",
+          name: "Prints",
+          itemListElement: {
+            "@type": "Offer",
+            itemOffered: {
+              "@type": "Product",
+              name: "Fine Art Prints",
+            },
+          },
+        },
+      ],
+    },
+  };
+
+  const breadcrumbSchema = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: "https://www.brushella.art",
+      },
+    ],
+  };
+
   return (
     <SEO
       pageTitle="Original Paintings & Fine Art Prints"
@@ -53,6 +114,12 @@ export const Head = (props: any) => {
       <script type="application/ld+json">{JSON.stringify(websiteSchema)}</script>
       <script type="application/ld+json">
         {JSON.stringify(organizationSchema)}
+      </script>
+      <script type="application/ld+json">
+        {JSON.stringify(storeSchema)}
+      </script>
+      <script type="application/ld+json">
+        {JSON.stringify(breadcrumbSchema)}
       </script>
     </SEO>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -52,7 +52,7 @@ export const Head = (props: any) => {
     image:
       "https://cdn.shopify.com/s/files/1/0586/9892/4240/files/web-asset-author.jpg?v=1729679585",
     description:
-      "Online art store featuring original paintings, fine art prints and home décor by Australian artist Gabriela.",
+      "Online art store featuring original paintings, fine art prints and home décor by Chilean artist Brushella.",
     priceRange: "$$",
     currenciesAccepted: "AUD",
     paymentAccepted: "Credit Card, Shop Pay",

--- a/src/templates/Collection.tsx
+++ b/src/templates/Collection.tsx
@@ -229,7 +229,7 @@ const Collection: React.FunctionComponent<CollectionProps> = ({
 export default Collection;
 
 export const Head = (props: any) => {
-  const { title } = props.pageContext;
+  const { title, products, collectionHandle, description } = props.pageContext;
   const canonical = `https://www.brushella.art${props.location.pathname}`;
 
   const breadcrumbSchema = {
@@ -252,6 +252,28 @@ export const Head = (props: any) => {
     ],
   };
 
+  const collectionSchema = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: title,
+    description:
+      description ||
+      `Browse the ${title} collection by Brushella.`,
+    url: canonical,
+    mainEntity: {
+      "@type": "ItemList",
+      numberOfItems: products?.length ?? 0,
+      itemListElement:
+        products?.map((product: any, index: number) => ({
+          "@type": "ListItem",
+          position: index + 1,
+          url: `https://www.brushella.art/collections/${collectionHandle}/${product.handle}/`,
+          name: product.title,
+          image: product.featuredImage?.originalSrc,
+        })) ?? [],
+    },
+  };
+
   return (
     <SEO
       pageTitle={`${title} — Art Collection`}
@@ -260,6 +282,9 @@ export const Head = (props: any) => {
     >
       <script type="application/ld+json">
         {JSON.stringify(breadcrumbSchema)}
+      </script>
+      <script type="application/ld+json">
+        {JSON.stringify(collectionSchema)}
       </script>
     </SEO>
   );


### PR DESCRIPTION
Add schema.org Store type with offer catalog, payment info, and founder details. Add BreadcrumbList for rich search results.