### PR TITLE
fix: restore cart from localStorage and create new cart when invalid

### DIFF
--- a/src/context/StoreContext.tsx
+++ b/src/context/StoreContext.tsx
@@ -235,15 +235,57 @@ const StoreApp = ({ children }: { children: React.ReactNode }) => {
     return id;
   })();
 
+  const createNewCart = useCallback(() => {
+    setStore((prevState) => {
+      return { ...prevState, isLoading: true };
+    });
+    clientV2
+      .request<Mutation>(createCartMutation, {
+        variables: {
+          input: {},
+        },
+      })
+      .then(({ data, errors }) => {
+        if (errors) {
+          setStore((prevState) => {
+            return { ...prevState, isLoading: false, hasResponseError: true };
+          });
+          return;
+        }
+        if (data && data.cartCreate && data.cartCreate.cart) {
+          localStorage.setItem(
+            SHOPIFY_CHECKOUT_LOCAL_STORAGE_KEY,
+            data.cartCreate.cart.id,
+          );
+          localStorage.setItem(
+            SHOPIFY_CHECKOUT_TIMESTAMP_KEY,
+            Date.now().toString(),
+          );
+          setStore((prevState) => {
+            return {
+              ...prevState,
+              isLoading: false,
+              cart: data.cartCreate?.cart,
+            };
+          });
+        }
+      })
+      .catch(() => {
+        setStore((prevState) => ({
+          ...prevState,
+          isLoading: false,
+          hasResponseError: true,
+        }));
+      });
+  }, []);
+
   useEffect(() => {
     if (existingCheckoutId) {
-      // retrieve existing cart
-
       setStore((prevState) => {
         return { ...prevState, isLoading: true };
       });
 
-      store.client
+      clientV2
         .request<QueryRoot>(cartQuery, {
           variables: {
             id: existingCheckoutId,
@@ -258,75 +300,37 @@ const StoreApp = ({ children }: { children: React.ReactNode }) => {
           }
 
           if (!data?.cart) {
-            // if no cart found, remove invalid cart id from local storage
-            typeof window !== "undefined" &&
-              localStorage.removeItem(SHOPIFY_CHECKOUT_LOCAL_STORAGE_KEY);
-            setStore((prevState) => {
-              return { ...prevState, isLoading: false };
-            });
+            localStorage.removeItem(SHOPIFY_CHECKOUT_LOCAL_STORAGE_KEY);
+            localStorage.removeItem(SHOPIFY_CHECKOUT_TIMESTAMP_KEY);
+            createNewCart();
             return;
           }
 
-          if (data && data.cart) {
-            typeof window !== "undefined" &&
-              localStorage.setItem(
-                SHOPIFY_CHECKOUT_LOCAL_STORAGE_KEY,
-                data.cart.id,
-              );
-            typeof window !== "undefined" &&
-              localStorage.setItem(
-                SHOPIFY_CHECKOUT_TIMESTAMP_KEY,
-                Date.now().toString(),
-              );
-            setStore((prevState) => {
-              return {
-                ...prevState,
-                isLoading: false,
-                cart: data.cart,
-              };
-            });
-          }
-        });
-    }
-
-    if (!existingCheckoutId) {
-      // create new cart
-      setStore((prevState) => {
-        return { ...prevState, isLoading: true };
-      });
-      store.client
-        .request<Mutation>(createCartMutation, {
-          variables: {
-            input: {},
-          },
+          localStorage.setItem(
+            SHOPIFY_CHECKOUT_LOCAL_STORAGE_KEY,
+            data.cart.id,
+          );
+          localStorage.setItem(
+            SHOPIFY_CHECKOUT_TIMESTAMP_KEY,
+            Date.now().toString(),
+          );
+          setStore((prevState) => {
+            return {
+              ...prevState,
+              isLoading: false,
+              cart: data.cart,
+            };
+          });
         })
-        .then(({ data, errors }) => {
-          if (errors) {
-            setStore((prevState) => {
-              return { ...prevState, isLoading: false, hasResponseError: true };
-            });
-            return;
-          }
-          if (data && data.cartCreate && data.cartCreate.cart) {
-            typeof window !== "undefined" &&
-              localStorage.setItem(
-                SHOPIFY_CHECKOUT_LOCAL_STORAGE_KEY,
-                data.cartCreate.cart.id,
-              );
-            typeof window !== "undefined" &&
-              localStorage.setItem(
-                SHOPIFY_CHECKOUT_TIMESTAMP_KEY,
-                Date.now().toString(),
-              );
-            setStore((prevState) => {
-              return {
-                ...prevState,
-                isLoading: false,
-                cart: data.cartCreate?.cart,
-              };
-            });
-          }
+        .catch(() => {
+          setStore((prevState) => ({
+            ...prevState,
+            isLoading: false,
+            hasResponseError: true,
+          }));
         });
+    } else {
+      createNewCart();
     }
   }, []);
 

--- a/src/context/__tests__/StoreContext.spec.tsx
+++ b/src/context/__tests__/StoreContext.spec.tsx
@@ -22,6 +22,9 @@ jest.mock("@shopify/storefront-api-client", () => ({
   }),
 }));
 
+const CHECKOUT_ID_KEY = "shopify_checkout_id";
+const TIMESTAMP_KEY = "shopify_checkout_timestamp";
+
 const cartCreateSuccess = {
   data: {
     cartCreate: {
@@ -35,6 +38,47 @@ const cartCreateSuccess = {
       userErrors: [],
       warnings: [],
     },
+  },
+};
+
+const cartQuerySuccessWithItems = {
+  data: {
+    cart: {
+      id: "gid://shopify/Cart/existing-cart-id",
+      createdAt: "2026-04-01T00:00:00Z",
+      updatedAt: "2026-04-01T00:00:00Z",
+      checkoutUrl: "https://brushellashop.myshopify.com/checkouts/existing",
+      cost: {
+        subtotalAmount: { amount: "25.00", currencyCode: "AUD" },
+        subtotalAmountEstimated: false,
+        totalAmount: { amount: "25.00", currencyCode: "AUD" },
+        totalAmountEstimated: false,
+      },
+      totalQuantity: 1,
+      lines: {
+        nodes: [
+          {
+            id: "gid://shopify/CartLine/1",
+            quantity: 1,
+            merchandise: {
+              __typename: "ProductVariant",
+              id: "gid://shopify/ProductVariant/1",
+              title: "Default",
+              product: { availableForSale: true, title: "Test Print" },
+              image: null,
+              price: { amount: "25.00", currencyCode: "AUD" },
+              unitPrice: null,
+            },
+          },
+        ],
+      },
+    },
+  },
+};
+
+const cartQueryNotFound = {
+  data: {
+    cart: null,
   },
 };
 
@@ -67,8 +111,14 @@ const TestConsumer = ({
   );
 };
 
+function seedLocalStorage(cartId: string) {
+  localStorage.setItem(CHECKOUT_ID_KEY, cartId);
+  localStorage.setItem(TIMESTAMP_KEY, Date.now().toString());
+}
+
 describe("StoreApp", () => {
   beforeEach(() => {
+    localStorage.clear();
     mockRequest = jest.fn().mockResolvedValue(cartCreateSuccess);
   });
 
@@ -103,7 +153,122 @@ describe("StoreApp", () => {
   });
 });
 
+describe("Cart restoration from localStorage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("restores an existing valid cart and shows correct item count", async () => {
+    seedLocalStorage("gid://shopify/Cart/existing-cart-id");
+    mockRequest = jest.fn().mockResolvedValueOnce(cartQuerySuccessWithItems);
+
+    render(
+      <StoreApp>
+        <TestConsumer />
+      </StoreApp>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("loading").textContent).toBe("false")
+    );
+
+    expect(screen.getByTestId("count").textContent).toBe("1");
+    expect(screen.getByTestId("items").textContent).toBe("1");
+    expect(screen.getByTestId("totals").textContent).toBe("has-totals");
+    expect(localStorage.getItem(CHECKOUT_ID_KEY)).toBe(
+      "gid://shopify/Cart/existing-cart-id"
+    );
+  });
+
+  it("creates a new cart when Shopify returns null for stored cart ID", async () => {
+    seedLocalStorage("gid://shopify/Cart/deleted-cart-id");
+    mockRequest = jest.fn()
+      .mockResolvedValueOnce(cartQueryNotFound)
+      .mockResolvedValueOnce(cartCreateSuccess);
+
+    render(
+      <StoreApp>
+        <TestConsumer />
+      </StoreApp>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("loading").textContent).toBe("false")
+    );
+
+    expect(screen.getByTestId("count").textContent).toBe("0");
+    expect(localStorage.getItem(CHECKOUT_ID_KEY)).toBe(
+      "gid://shopify/Cart/test-cart-id"
+    );
+  });
+
+  it("clears expired cart from localStorage and creates a new one", async () => {
+    localStorage.setItem(CHECKOUT_ID_KEY, "gid://shopify/Cart/old-cart-id");
+    const thirtyOneDaysAgo = Date.now() - 31 * 24 * 60 * 60 * 1000;
+    localStorage.setItem(TIMESTAMP_KEY, thirtyOneDaysAgo.toString());
+
+    mockRequest = jest.fn().mockResolvedValueOnce(cartCreateSuccess);
+
+    render(
+      <StoreApp>
+        <TestConsumer />
+      </StoreApp>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("loading").textContent).toBe("false")
+    );
+
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem(CHECKOUT_ID_KEY)).toBe(
+      "gid://shopify/Cart/test-cart-id"
+    );
+  });
+
+  it("sets hasResponseError when cart fetch fails with network error", async () => {
+    seedLocalStorage("gid://shopify/Cart/existing-cart-id");
+    mockRequest = jest.fn().mockRejectedValueOnce(new Error("Network error"));
+
+    render(
+      <StoreApp>
+        <TestConsumer />
+      </StoreApp>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("loading").textContent).toBe("false")
+    );
+
+    expect(screen.getByTestId("error").textContent).toBe("true");
+    expect(screen.getByTestId("count").textContent).toBe("0");
+  });
+
+  it("sets hasResponseError when cart creation fails with network error", async () => {
+    mockRequest = jest.fn().mockRejectedValueOnce(new Error("Network error"));
+
+    render(
+      <StoreApp>
+        <TestConsumer />
+      </StoreApp>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("loading").textContent).toBe("false")
+    );
+
+    expect(screen.getByTestId("error").textContent).toBe("true");
+  });
+});
+
 describe("useCartLinesUpdate .catch()", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -135,6 +300,10 @@ describe("useCartLinesUpdate .catch()", () => {
 });
 
 describe("useRemoveItemFromCart .catch()", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });


### PR DESCRIPTION
When a stored cart ID no longer exists on Shopify (e.g. after completed checkout), create a fresh cart instead of leaving the user with no cart. Also add .catch() to cart fetch and cart create to handle network errors.

- Extract createNewCart into reusable callback for both init paths
- Create new cart when Shopify returns null for stored cart ID
- Add .catch() handlers to cart fetch and cart creation
- Fix localStorage bleed between tests
- Add 5 new tests for cart restoration, expiry, and error handling