### PR TITLE
fix: guard homepage slider against missing metaobject link

### DIFF
--- a/src/components/HomePageSlider.tsx
+++ b/src/components/HomePageSlider.tsx
@@ -16,7 +16,7 @@ type FlattenedImage = {
     };
   };
   alt_text: string;
-  link: {
+  link?: {
     text: string;
     url: string;
   };
@@ -183,15 +183,21 @@ export const HomePageSlider: React.FC<HomePageSliderProps> = ({
               </picture>
 
               <div className="absolute bottom-10 left-4 max-w-[80%] bg-black/70 text-white  px-4 py-2 rounded-lg">
-                <Link
-                  to={item.link.url}
-                  className="slide-caption block
-                    font-serif font-medium mb-1 text-lg"
-                >
-                  <p className="leading-snug line-clamp-2 min-h-fit">
+                {item.link?.url ? (
+                  <Link
+                    to={item.link.url}
+                    className="slide-caption block
+                      font-serif font-medium mb-1 text-lg"
+                  >
+                    <p className="leading-snug line-clamp-2 min-h-fit">
+                      {item.caption}
+                    </p>
+                  </Link>
+                ) : (
+                  <p className="slide-caption font-serif font-medium mb-1 text-lg leading-snug line-clamp-2 min-h-fit">
                     {item.caption}
                   </p>
-                </Link>
+                )}
               </div>
             </div>
           </SwiperSlide>

--- a/src/components/__tests__/HomePageSlider.spec.tsx
+++ b/src/components/__tests__/HomePageSlider.spec.tsx
@@ -111,6 +111,18 @@ const MOCKED_IMAGES_PROPS = [
     },
     title: "Parrot",
   },
+  {
+    alt_text: "testing 7",
+    caption: "No link caption.",
+    category: "prints",
+    image: "gid://fake/MediaImage/34432890437841",
+    reference: {
+      image: {
+        url: "https://fake.images.fake/s/files/1/0586/9892/4240/files/no_link.jpg?v=1751945326",
+      },
+    },
+    title: "No link",
+  },
 ];
 
 beforeEach(() => {
@@ -159,7 +171,7 @@ describe("HomePageSlider", () => {
       <HomePageSlider images={MOCKED_IMAGES_PROPS} initialLoading={false} />
     );
 
-    MOCKED_IMAGES_PROPS.forEach((item, index) => {
+    MOCKED_IMAGES_PROPS.filter((item) => item.link).forEach((item) => {
       expect(
         screen.getByRole("link", { name: item.caption })
       ).toBeInTheDocument();
@@ -168,5 +180,18 @@ describe("HomePageSlider", () => {
         "https://www.brushella.art/"
       );
     });
+  });
+
+  it("renders caption as plain text when an image has no link", () => {
+    render(
+      <HomePageSlider images={MOCKED_IMAGES_PROPS} initialLoading={false} />
+    );
+
+    const noLinkItem = MOCKED_IMAGES_PROPS.find((item) => !item.link);
+    expect(noLinkItem).toBeDefined();
+    expect(screen.getByText(noLinkItem!.caption)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: noLinkItem!.caption })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/hooks/useMetaobjectToHeroSlider.ts
+++ b/src/hooks/useMetaobjectToHeroSlider.ts
@@ -8,7 +8,7 @@ type FlattenedImage = {
     };
   };
   alt_text: string;
-  link: {
+  link?: {
     text: string;
     url: string;
   };


### PR DESCRIPTION
## Summary
- The `link` field in the `homepage_slider_content` metaobject is now optional, which caused `HomePageSlider` to crash on the home page with `Cannot read properties of undefined (reading 'url')` when any slide lacked a link.
- Made `link` optional in the `FlattenedImage` types and conditionally render the slide caption as a `<Link>` when a URL exists, or as plain text otherwise.
- Added a mock entry without a link and a unit test asserting the caption renders as plain text (not a link) in that case.

## Test plan
- [x] `npm run test:unit -- src/components/__tests__/HomePageSlider.spec.tsx` — all 5 tests pass
- [ ] Manual: load the home page with a slider entry that has no link; confirm no runtime error and caption renders without an anchor
- [ ] Manual: confirm slides with links still navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)