### PR TITLE
feat: add view AR for android in collections

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -28,7 +28,9 @@ export const createPages: GatsbyNode["createPages"] = async ({
 
       allShopifyCollection(
         filter: {
-          handle: { in: ["prints", "original-paintings", "human-nature", "bloom"] }
+          handle: {
+            in: ["prints", "original-paintings", "human-nature", "bloom"]
+          }
           products: { elemMatch: { status: { eq: ACTIVE } } }
         }
       ) {
@@ -134,6 +136,13 @@ export const createPages: GatsbyNode["createPages"] = async ({
                   transformedSrc
                 }
               }
+              ... on ShopifyModel3d {
+                sources {
+                  url
+                  format
+                  mimeType
+                }
+              }
             }
             options {
               shopifyId
@@ -159,7 +168,7 @@ export const createPages: GatsbyNode["createPages"] = async ({
 
   const collectionsAndProductsResult =
     await graphql<Queries.CollectionsAndProductsIntoPagesQuery>(
-      print(COLLECTIONS_AND_PRODUCTS_DATA)
+      print(COLLECTIONS_AND_PRODUCTS_DATA),
     );
 
   if (
@@ -168,14 +177,11 @@ export const createPages: GatsbyNode["createPages"] = async ({
   ) {
     reporter.panicOnBuild(
       `There was an error loading the createPages query results for CollectionsAndProductsIntoPages`,
-      collectionsAndProductsResult.errors
+      collectionsAndProductsResult.errors,
     );
     return;
   }
-  const SPECIAL_COLLECTION_HANDLES = [
-    "human-nature",
-    "bloom",
-  ];
+  const SPECIAL_COLLECTION_HANDLES = ["human-nature", "bloom"];
 
   collectionsAndProductsResult.data?.allShopifyCollection.nodes.map((node) => {
     const isSpecial = SPECIAL_COLLECTION_HANDLES.includes(node.handle);
@@ -184,7 +190,7 @@ export const createPages: GatsbyNode["createPages"] = async ({
       component: path.resolve(
         isSpecial
           ? `./src/templates/SpecialCollection.tsx`
-          : `./src/templates/Collection.tsx`
+          : `./src/templates/Collection.tsx`,
       ),
       context: {
         title: node.title,
@@ -199,7 +205,7 @@ export const createPages: GatsbyNode["createPages"] = async ({
       const printVersionGID = product.printVersion?.value;
       const printVersionItem =
         collectionsAndProductsResult.data?.allShopifyProduct.nodes.find(
-          (printNode) => printNode.shopifyId === printVersionGID
+          (printNode) => printNode.shopifyId === printVersionGID,
         );
       createPage({
         path: `/collections/${node.handle}/${product.handle}`,
@@ -240,7 +246,7 @@ export const createPages: GatsbyNode["createPages"] = async ({
   if (adminContentResult.errors || !adminContentResult.data) {
     reporter.panicOnBuild(
       `There was an error loading the createPages query results for AdminContentIntoPages`,
-      adminContentResult.errors
+      adminContentResult.errors,
     );
     return;
   }
@@ -251,7 +257,7 @@ export const createPages: GatsbyNode["createPages"] = async ({
   ];
   const createPageFromField = (
     type: string,
-    field: Queries.AdminContentIntoPagesQuery["adminshopify"]["metaobjectDefinitions"]["nodes"][0]["metaobjects"]["nodes"][0]["fields"][0]
+    field: Queries.AdminContentIntoPagesQuery["adminshopify"]["metaobjectDefinitions"]["nodes"][0]["metaobjects"]["nodes"][0]["fields"][0],
   ) => {
     const pathRoot = `/${kebabCase(type)}`;
     const fieldKey = `${kebabCase(field.key)}`;

--- a/src/components/ARButton.tsx
+++ b/src/components/ARButton.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { IconButton } from "@chakra-ui/react";
+import { TbAugmentedReality as ARIcon } from "react-icons/tb";
+import { useIsAndroid } from "../hooks/useIsAndroid";
+
+interface ARButtonProps {
+  glbUrl: string;
+  productTitle: string;
+  browserFallbackUrl: string;
+}
+
+const ARButton: React.FC<ARButtonProps> = ({
+  glbUrl,
+  productTitle,
+  browserFallbackUrl,
+}) => {
+  const isAndroid = useIsAndroid();
+
+  // SSR / non-Android => render nothing
+  if (!isAndroid) return null;
+
+  // Documentation: https://developers.google.com/ar/develop/scene-viewer#supported_intent_parameters
+  const intentLinkParams = new URLSearchParams({
+    file: glbUrl,
+    mode: "ar_only",
+    title: productTitle,
+    link: browserFallbackUrl,
+    resizable: "false",
+    enable_vertical_placement: "true",
+  });
+
+  const intentUrl =
+    `intent://arvr.google.com/scene-viewer/1.1?${intentLinkParams.toString()}` +
+    `#Intent;scheme=https;package=com.google.android.googlequicksearchbox;` +
+    `action=android.intent.action.VIEW;` +
+    `S.browser_fallback_url=${encodeURIComponent(browserFallbackUrl)};end;`;
+
+  return (
+    <IconButton
+      as="a"
+      title="View AR"
+      href={intentUrl}
+      rel="ar"
+      aria-label="View AR"
+      bgColor="#702459"
+      icon={<ARIcon size={25} color="#fff" aria-hidden />}
+      fontSize={"xs"}
+      color="#fff"
+      borderRadius="md"
+      _hover={{ bgColor: "#319795" }}
+    />
+  );
+};
+
+export default ARButton;

--- a/src/components/__tests__/ARButton.spec.tsx
+++ b/src/components/__tests__/ARButton.spec.tsx
@@ -1,0 +1,43 @@
+import React from "react"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import ARButton from "../ARButton";
+import { useIsAndroid } from "../../hooks/useIsAndroid";
+
+jest.mock("../../hooks/useIsAndroid");
+
+const mockUseIsAndroid = useIsAndroid as jest.MockedFunction<typeof useIsAndroid>;
+
+const defaultProps = {
+  glbUrl: "https://example.com/model.glb",
+  productTitle: "Test Artwork",
+  browserFallbackUrl: "https://example.com/product",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("ARButton", () => {
+  it("renders nothing on non-Android devices", () => {
+    mockUseIsAndroid.mockReturnValue(false);
+    const { asFragment } = render(<ARButton {...defaultProps} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("renders nothing while SSR / before mount (null)", () => {
+    mockUseIsAndroid.mockReturnValue(null);
+    const { asFragment } = render(<ARButton {...defaultProps} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("renders the AR icon button on Android devices", () => {
+    mockUseIsAndroid.mockReturnValue(true);
+    const { asFragment } = render(<ARButton {...defaultProps} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/components/__tests__/__snapshots__/ARButton.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ARButton.spec.tsx.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ARButton renders nothing on non-Android devices 1`] = `<DocumentFragment />`;
+
+exports[`ARButton renders nothing while SSR / before mount (null) 1`] = `<DocumentFragment />`;
+
+exports[`ARButton renders the AR icon button on Android devices 1`] = `
+<DocumentFragment>
+  <a
+    aria-label="View AR"
+    class="chakra-button css-gg5z3"
+    href="intent://arvr.google.com/scene-viewer/1.1?file=https%3A%2F%2Fexample.com%2Fmodel.glb&mode=ar_only&title=Test+Artwork&link=https%3A%2F%2Fexample.com%2Fproduct&resizable=false&enable_vertical_placement=true#Intent;scheme=https;package=com.google.android.googlequicksearchbox;action=android.intent.action.VIEW;S.browser_fallback_url=https%3A%2F%2Fexample.com%2Fproduct;end;"
+    rel="ar"
+    title="View AR"
+  >
+    <svg
+      aria-hidden="true"
+      color="#fff"
+      fill="none"
+      focusable="false"
+      height="25"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      style="color: rgb(255, 255, 255);"
+      viewBox="0 0 24 24"
+      width="25"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M0 0h24v24H0z"
+        fill="none"
+        stroke="none"
+      />
+      <path
+        d="M4 8v-2a2 2 0 0 1 2 -2h2"
+      />
+      <path
+        d="M4 16v2a2 2 0 0 0 2 2h2"
+      />
+      <path
+        d="M16 4h2a2 2 0 0 1 2 2v2"
+      />
+      <path
+        d="M16 20h2a2 2 0 0 0 2 -2v-2"
+      />
+      <path
+        d="M12 12.5l4 -2.5"
+      />
+      <path
+        d="M8 10l4 2.5v4.5l4 -2.5v-4.5l-4 -2.5z"
+      />
+      <path
+        d="M8 10v4.5l4 2.5"
+      />
+    </svg>
+  </a>
+</DocumentFragment>
+`;

--- a/src/hooks/useIsAndroid.ts
+++ b/src/hooks/useIsAndroid.ts
@@ -1,0 +1,27 @@
+// src/hooks/useIsAndroid.ts
+import { useEffect, useState } from "react";
+
+/**
+ * Detects Android via UA. Runs only on the client.
+ * Returns `null` until mounted to avoid SSR/CSR mismatch in Gatsby.
+ */
+export function useIsAndroid(): boolean | null {
+  const [isAndroid, setIsAndroid] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    // Prefer UA-CH when available, fall back to userAgent string.
+    const uaData = (
+      navigator as Navigator & {
+        userAgentData?: { platform?: string };
+      }
+    ).userAgentData;
+
+    if (uaData?.platform) {
+      setIsAndroid(uaData.platform.toLowerCase() === "android");
+      return;
+    }
+    setIsAndroid(/android/i.test(navigator.userAgent));
+  }, []);
+
+  return isAndroid;
+}

--- a/src/templates/SpecialCollection.tsx
+++ b/src/templates/SpecialCollection.tsx
@@ -15,13 +15,16 @@ import {
   SimpleGrid,
   Stack,
   Text,
+  LinkOverlay,
+  LinkBox,
 } from "@chakra-ui/react";
 import { GatsbyImage, StaticImage, getImage } from "gatsby-plugin-image";
-import { Link } from "gatsby";
+import { Link as GatsbyLink } from "gatsby";
 import SEO from "../components/SEO";
 import CollectionHero from "../components/CollectionHero";
+import ARButton from "../components/ARButton";
+
 import { ArrowForwardIcon } from "@chakra-ui/icons";
-import { TbAugmentedReality } from "react-icons/tb";
 
 type SpecialCollectionProps = {
   pageContext: {
@@ -93,39 +96,40 @@ const SpecialCollection: React.FunctionComponent<SpecialCollectionProps> = ({
               const featuredImageForGatsbyImage = getImage(
                 featuredImage?.grid ?? null,
               );
-              const arHref = `https://arvr.google.com/scene-viewer/1.0?file=PLACEHOLDER_${handle}`;
+
+              const glbUrl: string =
+                product.media
+                  ?.find((m) => m.mediaContentType === "MODEL_3D")
+                  // @ts-expect-error sources exists on ShopifyModel3d via inline fragment
+                  ?.sources?.find(
+                    (s: { format: string; url: string }) => s.format === "glb",
+                  )?.url ?? "";
+
               return (
                 <Card
                   key={`${id}-product-item`}
                   position="relative"
                   boxShadow="md"
                   height="100%"
+                  as={LinkBox}
                 >
                   <Box
-                    as="a"
-                    href={arHref}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label={`View ${productTitle} in augmented reality`}
                     position="absolute"
                     top="0.75rem"
                     right="0.75rem"
                     zIndex={2}
-                    display="inline-flex"
-                    alignItems="center"
-                    justifyContent="center"
-                    bg="pink.800"
-                    color="white"
-                    p="0.4rem"
-                    borderRadius="md"
-                    boxShadow="sm"
-                    _hover={{ bg: "teal.500" }}
-                    _focus={{ bg: "teal.500", outline: "2px solid white" }}
                   >
-                    <Icon as={TbAugmentedReality} boxSize="1.25rem" />
+                    {glbUrl && (
+                      <ARButton
+                        glbUrl={glbUrl}
+                        productTitle={productTitle}
+                        browserFallbackUrl={`https://www.brushella.art/collections/${collectionHandle}`}
+                      />
+                    )}
                   </Box>
-                  <Link
+                  <LinkOverlay
                     key={handle}
+                    as={GatsbyLink}
                     to={`/collections/${collectionHandle}/${handle}`}
                     aria-label={productTitle}
                   >
@@ -199,17 +203,20 @@ const SpecialCollection: React.FunctionComponent<SpecialCollectionProps> = ({
                           </Text>
                         </Box>
                       )}
-                      <Text
-                        fontSize="md"
-                        textAlign="right"
-                        color={"pink.800"}
-                        marginLeft="auto"
-                        className="translate-y-1 hover:translate-y-0 transition-transform duration-300 ease-in-out"
-                      >
-                        more details <Icon as={ArrowForwardIcon} />
-                      </Text>
+                      <Box>
+                        <Text
+                          fontSize="md"
+                          textAlign="right"
+                          color={"pink.800"}
+                          marginLeft="auto"
+                          cursor={"pointer"}
+                          className="translate-y-1 hover:translate-y-0 transition-transform duration-300 ease-in-out"
+                        >
+                          more details <Icon as={ArrowForwardIcon} />
+                        </Text>
+                      </Box>
                     </CardFooter>
-                  </Link>
+                  </LinkOverlay>
                 </Card>
               );
             };

--- a/src/templates/__tests__/SpecialCollection.spec.tsx
+++ b/src/templates/__tests__/SpecialCollection.spec.tsx
@@ -31,6 +31,10 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.clearAllMocks();
+  Object.defineProperty(navigator, "userAgent", {
+    value: "",
+    configurable: true,
+  });
 });
 
 const baseProduct = {
@@ -86,7 +90,7 @@ describe("SpecialCollection page Template", () => {
 
     // No "Read more" link
     expect(
-      screen.queryByRole("link", { name: /Read more/i })
+      screen.queryByRole("link", { name: /Read more/i }),
     ).not.toBeInTheDocument();
 
     // Full product card renders below the hero
@@ -94,20 +98,8 @@ describe("SpecialCollection page Template", () => {
     screen.getByText(/AUD/i);
     screen.getByText(/\$10/i);
     expect(
-      screen.getByRole("link", { name: "Test product name" })
+      screen.getByRole("link", { name: "Test product name" }),
     ).toHaveAttribute("href", "/collections/human-nature/test-product-handle");
-
-    // AR badge with placeholder Google Scene Viewer deep link
-    const arLink = screen.getByRole("link", {
-      name: /View Test product name in augmented reality/i,
-    });
-    expect(arLink).toHaveAttribute(
-      "href",
-      "https://arvr.google.com/scene-viewer/1.0?file=PLACEHOLDER_test-product-handle"
-    );
-    expect(arLink).toHaveAttribute("target", "_blank");
-    expect(arLink).toHaveAttribute("rel", "noopener noreferrer");
-    expect(arLink.querySelector("svg")).toBeInTheDocument();
   });
 
   it("renders the human-nature fallback description when none is provided", () => {
@@ -125,7 +117,7 @@ describe("SpecialCollection page Template", () => {
     render(<SpecialCollection pageContext={mockedPageContext as any} />);
 
     expect(
-      screen.getByText(/meditation on the body's quiet wonders/i)
+      screen.getByText(/meditation on the body's quiet wonders/i),
     ).toBeInTheDocument();
   });
 
@@ -145,5 +137,75 @@ describe("SpecialCollection page Template", () => {
     render(<SpecialCollection pageContext={mockedPageContext as any} />);
     screen.getByText("There are no products available.");
     screen.getByRole("heading", { name: "Bloom Collection" });
+  });
+
+  it("does not render the AR button on non-Android (desktop) devices", () => {
+    const productWithGlb = {
+      ...baseProduct,
+      media: [
+        {
+          mediaContentType: "MODEL_3D",
+          sources: [
+            { format: "glb", url: "https://cdn.example.com/model.glb" },
+          ],
+        },
+      ],
+    };
+
+    const mockedPageContext = {
+      title: "Human Nature",
+      description: "A collection inspired by the human condition.",
+      collectionHandle: "human-nature",
+      image: null,
+      products: [productWithGlb],
+    };
+
+    render(<SpecialCollection pageContext={mockedPageContext as any} />);
+
+    expect(
+      screen.queryByRole("link", { name: /View AR/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the AR button on Android devices when a GLB model is available", () => {
+    Object.defineProperty(navigator, "userAgent", {
+      value:
+        "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Mobile Safari/537.36",
+      configurable: true,
+    });
+
+    const productWithGlb = {
+      ...baseProduct,
+      media: [
+        {
+          mediaContentType: "MODEL_3D",
+          sources: [
+            { format: "glb", url: "https://cdn.example.com/model.glb" },
+          ],
+        },
+      ],
+    };
+
+    const mockedPageContext = {
+      title: "Human Nature",
+      description: "A collection inspired by the human condition.",
+      collectionHandle: "human-nature",
+      image: null,
+      products: [productWithGlb],
+    };
+
+    render(<SpecialCollection pageContext={mockedPageContext as any} />);
+
+    const arLink = screen.getByRole("link", { name: /View AR/i });
+    expect(arLink).toBeInTheDocument();
+    expect(arLink).toHaveAttribute(
+      "href",
+      expect.stringContaining("arvr.google.com/scene-viewer"),
+    );
+
+    expect(arLink).toHaveAttribute(
+      "href",
+      expect.stringContaining("cdn.example.com%2Fmodel.glb"),
+    );
   });
 });


### PR DESCRIPTION
frontend:
- introduced ARButton component
- introduced useIsAndroid react hook utility function
- imported ARButton component on SpecialCollections.tsx template visible on Android devices only
- AR_ONLY to prevent 3d model option
graphql:

- extended query `allShopifyCollection` with additional fields (needed to build the AR url):

```
 ... on ShopifyModel3d {
                sources {
                  url
                  format
                  mimeType
                }
              }
``` 

-  OK: tests (unit, etc)


e2e test on iphone (it should not show the button)
https://github.com/user-attachments/assets/fd44c475-cbeb-4587-b586-ebfe0c21705f

android and desktop are all good too
